### PR TITLE
Fix db_users variable notation in userlist.txt.erb

### DIFF
--- a/templates/userlist.txt.erb
+++ b/templates/userlist.txt.erb
@@ -1,3 +1,3 @@
-<% db_users.sort.each do |k, v| -%>
+<% @db_users.sort.each do |k, v| -%>
 "<%= k -%>" "<%= v -%>"
 <% end -%>


### PR DESCRIPTION
Puppet variables in templates must be accessed as '@myvar', not 'myvar',
so change 'db_users' to '@db_users' in the userlist.txt.erb template.